### PR TITLE
update Java API to unwrap the 'civilFileContentDoc' layer after recei…

### DIFF
--- a/ccd-common-models/src/main/java/ca/bc/gov/open/ccd/models/serializers/InstantSerializer.java
+++ b/ccd-common-models/src/main/java/ca/bc/gov/open/ccd/models/serializers/InstantSerializer.java
@@ -14,8 +14,8 @@ public class InstantSerializer extends JsonSerializer<Instant> {
     public void serialize(Instant value, JsonGenerator gen, SerializerProvider serializers)
             throws IOException {
         String out =
-                DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss")
-                        .withZone(ZoneId.of("GMT-7"))
+                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+                        .withZone(ZoneId.of("UTC"))
                         .withLocale(Locale.US)
                         .format(value);
         gen.writeString(out);
@@ -26,8 +26,8 @@ public class InstantSerializer extends JsonSerializer<Instant> {
             return null;
         }
 
-        return DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss")
-                .withZone(ZoneId.of("GMT-7"))
+        return DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+                .withZone(ZoneId.of("UTC"))
                 .withLocale(Locale.US)
                 .format(value);
     }

--- a/ccd-common-models/src/main/java/ca/bc/gov/open/ccd/models/serializers/InstantSoapConverter.java
+++ b/ccd-common-models/src/main/java/ca/bc/gov/open/ccd/models/serializers/InstantSoapConverter.java
@@ -3,6 +3,8 @@ package ca.bc.gov.open.ccd.models.serializers;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -13,9 +15,13 @@ public final class InstantSoapConverter {
 
     private InstantSoapConverter() {}
 
-    public static String print(Instant xml) {
-        String first = xml.toString();
-        return first.substring(0, first.length() - 1);
+    public static String print(Instant value) {
+        String out =
+                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.0")
+                        .withZone(ZoneId.of("UTC"))
+                        .withLocale(Locale.US)
+                        .format(value);
+        return out;
     }
 
     public static Instant parse(String value) {
@@ -24,14 +30,14 @@ public final class InstantSoapConverter {
             // Try to parse a datetime first then try date only if both fail return null
             try {
                 // Date time parser
-                var sdf = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss.SSSSSS", Locale.US);
-                sdf.setTimeZone(TimeZone.getTimeZone("GMT-7"));
+                var sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSSSS", Locale.US);
+                sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
                 d = sdf.parse(value);
             } catch (ParseException ex) {
                 // Date only parser
                 try {
                     var sdf = new SimpleDateFormat("dd-MMM-yy", Locale.US);
-                    sdf.setTimeZone(TimeZone.getTimeZone("GMT-7"));
+                    sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
                     d = sdf.parse(value);
                 } catch (ParseException ex2) {
                     return Instant.parse(value + "Z");

--- a/jag-ccd-application/src/main/java/ca/bc/gov/open/ccd/controllers/FileController.java
+++ b/jag-ccd-application/src/main/java/ca/bc/gov/open/ccd/controllers/FileController.java
@@ -1,7 +1,6 @@
 package ca.bc.gov.open.ccd.controllers;
 
 import ca.bc.gov.open.ccd.civil.*;
-import ca.bc.gov.open.ccd.civil.CivilFileContentDoc;
 import ca.bc.gov.open.ccd.civil.secure.*;
 import ca.bc.gov.open.ccd.common.criminal.file.content.*;
 import ca.bc.gov.open.ccd.common.criminal.file.content.secure.*;
@@ -155,15 +154,13 @@ public class FileController {
                         .queryParam("applicationCd", getCivilFileContent.getApplicationCd());
 
         try {
-            HttpEntity<CivilFileContentDoc> resp =
+            HttpEntity<GetCivilFileContentResponse> resp =
                     restTemplate.exchange(
                             builder.build().toUri(),
                             HttpMethod.GET,
                             new HttpEntity<>(new HttpHeaders()),
-                            CivilFileContentDoc.class);
-            var out = new GetCivilFileContentResponse();
-            out.setCivilFileContentDoc(resp.getBody());
-            return out;
+                            GetCivilFileContentResponse.class);
+            return resp.getBody();
         } catch (Exception ex) {
             log.error(
                     objectMapper.writeValueAsString(
@@ -207,7 +204,7 @@ public class FileController {
         try {
             HttpEntity<ca.bc.gov.open.ccd.civil.secure.GetCivilFileContentSecureResponse> resp =
                     restTemplate.exchange(
-                            builder.toUriString(),
+                            builder.build().toUri(),
                             HttpMethod.GET,
                             new HttpEntity<>(new HttpHeaders()),
                             ca.bc.gov.open.ccd.civil.secure.GetCivilFileContentSecureResponse

--- a/jag-ccd-application/src/test/java/ca/bc/gov/open/ccd/CodeControllerTests.java
+++ b/jag-ccd-application/src/test/java/ca/bc/gov/open/ccd/CodeControllerTests.java
@@ -131,8 +131,8 @@ public class CodeControllerTests {
         String out = objectMapper.writeValueAsString(time);
 
         String expected =
-                DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss")
-                        .withZone(ZoneId.of("GMT-7"))
+                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+                        .withZone(ZoneId.of("UTC"))
                         .withLocale(Locale.US)
                         .format(time);
 

--- a/jag-ccd-application/src/test/java/ca/bc/gov/open/ccd/FileControllerTests.java
+++ b/jag-ccd-application/src/test/java/ca/bc/gov/open/ccd/FileControllerTests.java
@@ -408,12 +408,15 @@ public class FileControllerTests {
         req.setPhysicalFileId("A");
         req.setApplicationCd("A");
 
-        var out = new CivilFileContentDoc();
-        out.setCourtLocaCd("A");
-        out.setCourtRoomCd("A");
-        out.setCourtProceedingDate(Instant.now());
-        out.setAppearanceId(Collections.singletonList("A"));
-        out.setPhysicalFileId("A");
+        var fileContentDoc = new CivilFileContentDoc();
+        fileContentDoc.setCourtLocaCd("A");
+        fileContentDoc.setCourtRoomCd("A");
+        fileContentDoc.setCourtProceedingDate(Instant.now());
+        fileContentDoc.setAppearanceId(Collections.singletonList("A"));
+        fileContentDoc.setPhysicalFileId("A");
+
+        var out = new GetCivilFileContentResponse();
+        out.setCivilFileContentDoc(fileContentDoc);
 
         var cft = new CivilFileType();
         cft.setPhysicalFileID("A");
@@ -555,9 +558,7 @@ public class FileControllerTests {
         rdi.setNonPartyName("A");
         rd.setReferenceDocumentInterest(Collections.singletonList(rdi));
 
-        out.setCivilFile(Collections.singletonList(cft));
-
-        ResponseEntity<CivilFileContentDoc> responseEntity =
+        ResponseEntity<GetCivilFileContentResponse> responseEntity =
                 new ResponseEntity<>(out, HttpStatus.OK);
 
         // Set up to mock ords response
@@ -565,7 +566,7 @@ public class FileControllerTests {
                         Mockito.any(URI.class),
                         Mockito.eq(HttpMethod.GET),
                         Mockito.<HttpEntity<String>>any(),
-                        Mockito.<Class<CivilFileContentDoc>>any()))
+                        Mockito.<Class<GetCivilFileContentResponse>>any()))
                 .thenReturn(responseEntity);
 
         FileController fileController = new FileController(restTemplate, objectMapper);
@@ -605,7 +606,7 @@ public class FileControllerTests {
 
         // Set up to mock ords response
         when(restTemplate.exchange(
-                        Mockito.any(String.class),
+                        Mockito.any(URI.class),
                         Mockito.eq(HttpMethod.GET),
                         Mockito.<HttpEntity<String>>any(),
                         Mockito.<Class<GetCivilFileContentSecureResponse>>any()))


### PR DESCRIPTION
…ving getCivilFileContent/getCivilFileContentSecure

# Description

This PR includes the following proposed change(s):

- update Java API to unwrap the 'civilFileContentDoc' layer after receiving getCivilFileContent/getC
ivilFileContentSecure"
- display correct receiving date time format 
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
