### PR TITLE
Civil File Get Update

### DIFF
--- a/ccd-civil-models/src/main/resources/xsdSchemas/civilFileContent.xsd
+++ b/ccd-civil-models/src/main/resources/xsdSchemas/civilFileContent.xsd
@@ -177,6 +177,7 @@
             <xsd:element name="SwornByNm" nillable="true" type="xsd:string"/>
             <xsd:element name="AffidavitNo" nillable="true" type="xsd:string"/>
             <xsd:element name="FilingLanguageCd" nillable="true" type="xsd:string"/>
+            <xsd:element name="TranslationExistsYN" nillable="true" type="xsd:string"/>
             <xsd:element name="Issue" nillable="true" type="tns:IssueType" maxOccurs="unbounded"/>
             <xsd:element name="Appearance" nillable="true" type="tns:AppearanceType" maxOccurs="unbounded"/>
             <xsd:element name="PartyInterest" nillable="true" type="tns:PartyInterestType" maxOccurs="unbounded"/>

--- a/jag-ccd-application/src/main/resources/xsdSchemas/civilFileContent.wsdl
+++ b/jag-ccd-application/src/main/resources/xsdSchemas/civilFileContent.wsdl
@@ -159,6 +159,7 @@
                     <xsd:element name="SwornByNm" nillable="true" type="xsd:string"/>
                     <xsd:element name="AffidavitNo" nillable="true" type="xsd:string"/>
                     <xsd:element name="FilingLanguageCd" nillable="true" type="xsd:string"/>
+                    <xsd:element name="TranslationExistsYN" nillable="true" type="xsd:string"/>
                     <xsd:element name="Issue" nillable="true" type="tns:IssueType" maxOccurs="unbounded"/>
                     <xsd:element name="Appearance" nillable="true" type="tns:AppearanceType" maxOccurs="unbounded"/>
                     <xsd:element name="PartyInterest" nillable="true" type="tns:PartyInterestType" maxOccurs="unbounded"/>


### PR DESCRIPTION
Added "TranslationExistsYN" flag to Document type to indicate that a document has a translated image with it.
